### PR TITLE
Fixed NEAR logging issue due to middleware

### DIFF
--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -3,17 +3,34 @@ import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
   const token = request.cookies.get('user')?.value;
-  console.log("Middleware Cookies:", request.cookies);
+  const url = request.nextUrl.clone();
+  const { pathname } = url;
 
-  if (!token) {
-    const loginUrl = new URL('/', request.url);
-    return NextResponse.redirect(loginUrl);
+  // Define public routes
+  const publicRoutes = ['/'];
+  const isPublicRoute = publicRoutes.includes(pathname);
+
+  // Redirect authenticated users from public routes to dashboard
+  if (token && isPublicRoute) {
+    url.pathname = '/dashboard';
+    return NextResponse.redirect(url);
   }
 
-  return NextResponse.next();
+  // Handle NEAR callback
+  const isNearCallback = url.searchParams.has('account_id') && 
+                        url.searchParams.has('public_key') && 
+                        url.searchParams.has('all_keys');
+
+  // Allow access to public routes or if authenticated or during NEAR callback
+  if (isPublicRoute || token || isNearCallback) {
+    return NextResponse.next();
+  }
+
+  // Redirect unauthenticated users to landing page
+  url.pathname = '/';
+  return NextResponse.redirect(url);
 }
 
 export const config = {
-    matcher: ['/dashboard/:path*'],
-  };
-  
+  matcher: ['/', '/dashboard/:path*'],
+};


### PR DESCRIPTION
- Added conditions to handle NEAR Callback while logging in
- Redirecting to /dashboard when token exists and accessing public route like '/'